### PR TITLE
Core: fix - discover count

### DIFF
--- a/BlockV/Core/Network/Params/DiscoverQueryBuilder.swift
+++ b/BlockV/Core/Network/Params/DiscoverQueryBuilder.swift
@@ -31,7 +31,6 @@ public class DiscoverQueryBuilder {
     /// Models the options for the structure and contents of the query's response.
     public enum ResultType: String {
         case payload = "*"
-        case count   = "count"
     }
 
     // MARK: - Properties

--- a/BlockV/Core/Network/Params/DiscoverQueryBuilder.swift
+++ b/BlockV/Core/Network/Params/DiscoverQueryBuilder.swift
@@ -169,7 +169,9 @@ extension DiscoverQueryBuilder: DictionaryCodable {
 
         payload["scope"] = self.scope
         let filterElems = self.filters.map { $0.toDictionary() } // map the filters to dictionaries
-        payload["filters"] = [["filter_elems": filterElems]] // filters is an array, the first element is 
+        if !filterElems.isEmpty {
+            payload["filters"] = [["filter_elems": filterElems]] // filters is an array, the first element is
+        }
         payload["return"] = self.resultStructure
 
         return payload

--- a/BlockV/Core/Requests/BLOCKv+VatomRequest.swift
+++ b/BlockV/Core/Requests/BLOCKv+VatomRequest.swift
@@ -149,25 +149,6 @@ extension BLOCKv {
         }
     }
 
-    /// Searches for the count (tally) of vAtoms on the BLOCKv platform.
-    ///
-    /// - Parameters:
-    ///   - builder: A discover query builder object. Use the builder to simplify constructing
-    ///              discover queries.
-    ///   - completion: The completion handler to call when the request is completed.
-    ///                 This handler is executed on the main queue.
-    ///   - count: Number of discovered vAtoms.
-    ///   - error: BLOCKv error.
-    public static func discoverCount(_ builder: DiscoverQueryBuilder,
-                                     completion: @escaping(_ count: Int?, _ error: BVError?) -> Void) {
-
-        // explicitlt set return type to payload
-        builder.setReturn(type: .count)
-        self.discover(payload: builder.toDictionary()) { (result, error) in
-            completion(result?.count, error)
-        }
-    }
-
     public typealias DiscoverResult = (vatoms: [VatomModel], count: Int)
 
     /// Performs a search for vAtoms on the BLOCKv platform.


### PR DESCRIPTION
- Depreciate discover count
- Only append `filter` array to discover payload if a filter element is present.