### PR TITLE
Core: Feature - username token

### DIFF
--- a/BlockV/Core/Network/Models/User/FullTokenModel.swift
+++ b/BlockV/Core/Network/Models/User/FullTokenModel.swift
@@ -22,6 +22,7 @@ public struct FullTokenModel: Codable, Equatable {
         public let appID: String
         public let isConfirmed: Bool
         public let isDefault: Bool
+        public let isDisabled: Bool
         public let token: String
         public let tokenType: String
         public let userID: String
@@ -31,6 +32,7 @@ public struct FullTokenModel: Codable, Equatable {
             case appID             = "app_id"
             case isConfirmed       = "confirmed"
             case isDefault         = "is_default"
+            case isDisabled        = "disabled"
             case token             = "token"
             case tokenType         = "token_type"
             case userID            = "user_id"

--- a/BlockV/Core/Network/Models/User/UserToken.swift
+++ b/BlockV/Core/Network/Models/User/UserToken.swift
@@ -24,9 +24,10 @@ import Foundation
 
 /// Models types of user tokens supported on the BLOCKv platform.
 public enum UserTokenType: String, Codable {
-    case phone = "phone_number"
-    case email = "email"
-    case id    = "id"
+    case phone      = "phone_number"
+    case email      = "email"
+    case id         = "id"
+    case username   = "username"
 }
 
 /// User token model.

--- a/BlockV/Core/Network/Stack/API.swift
+++ b/BlockV/Core/Network/Stack/API.swift
@@ -181,6 +181,28 @@ extension API {
             return Endpoint(method: .put,
                             path: currentUserPath + "/tokens/\(id)/default")
         }
+        
+        // MARK: Username
+        
+        /// Builds the endpoint to edit a username token.
+        ///
+        /// The endpoint is generic over a response model. This model is parsed on success responses (200...299).
+        static func updateUsernameToken(id: String, username: String) -> Endpoint<BaseModel<FullTokenModel>> {
+            return Endpoint(method: .patch,
+                            path: currentUserPath + "/tokens/\(id)",
+                            parameters: [
+                                "token": username,
+                                "token_type": "username"
+            ])
+        }
+        
+        /// Builds the endpoint to disable a username token.
+        ///
+        /// The endpoint is generic over a response model. This model is parsed on success responses (200...299).
+        static func disableUsername(tokenId: String) -> Endpoint<BaseModel<GeneralModel>> { //FIXME: General model is wrong
+            return Endpoint(method: .put,
+                            path: currentUserPath + "/tokens/\(tokenId)/disabled")
+        }
 
         // MARK: Avatar
 

--- a/Example/BlockV/Controllers/Actions/TransferActionViewController.swift
+++ b/Example/BlockV/Controllers/Actions/TransferActionViewController.swift
@@ -147,6 +147,9 @@ class TransferActionViewController: UIViewController {
         case .id:
             userTokenTextField.keyboardType = .asciiCapable
             userTokenTextField.placeholder = "User ID"
+        case .username:
+            userTokenTextField.keyboardType = .default
+            userTokenTextField.placeholder = "Username"
         }
     }
     


### PR DESCRIPTION
The PR adds support for usernames as tokens.

1. `FullTokenModel` gains a `isDisabled` property (which may only be `true` for username tokens).
2. `UserTokenType` gains a `username` case.
3. Two public functions have been added:
  - `updateUsernameToken(tokenID:newUsername:completion)`
  - `disableUsernameToken(tokenID:completion)`
4. Creating and deleting a token is done using the existing token functions.

Please feedback on functionality and naming.