### PR TITLE
Core: fix - vatom model unpublished

### DIFF
--- a/BlockV/Core/Network/Models/Package/VatomModel.swift
+++ b/BlockV/Core/Network/Models/Package/VatomModel.swift
@@ -69,11 +69,11 @@ extension VatomModel: Codable {
         let items = try decoder.container(keyedBy: CodingKeys.self)
         id                = try items.decode(String.self, forKey: .id)
         version           = try items.decode(String.self, forKey: .version)
-        isUnpublished     = try items.decode(Bool.self, forKey: .isUnpublished)
         whenCreated       = try items.decode(Date.self, forKey: .whenCreated)
         whenModified      = try items.decode(Date.self, forKey: .whenModified)
         props             = try items.decode(RootProperties.self, forKey: .props)
-
+        
+        isUnpublished     = try items.decodeIfPresent(Bool.self, forKey: .isUnpublished) ?? false
         `private`         = try items.decodeIfPresent(JSON.self, forKey: .private)
         eos               = try items.decodeIfPresent(JSON.self, forKey: .eos)
         eth               = try items.decodeIfPresent(JSON.self, forKey: .eth)


### PR DESCRIPTION
Allow for absent `unpublished` key. Default to `false` if absent.