### PR TITLE
Face: Fix - Expand VatomViewDelegate 

### DIFF
--- a/BlockV/Face/Face Views/Web/WebScriptMessageHandler.swift
+++ b/BlockV/Face/Face Views/Web/WebScriptMessageHandler.swift
@@ -234,7 +234,7 @@ extension WebFaceView {
 
     /// Routes the script message to the viewer and handles the response.
     private func routeMessageToViewer(_ message: RequestScriptMessage) {
-        
+
         // notify the host's message delegate of the custom message from the web page
         self.delegate?.faceView(self,
                                 didSendMessage: message.name,
@@ -253,7 +253,7 @@ extension WebFaceView {
                                         return
                                     }
         })
-        
+
     }
 
     /// Transforms viewer message from protocol V1 to V2.

--- a/BlockV/Face/Face Views/Web/WebScriptMessageHandler.swift
+++ b/BlockV/Face/Face Views/Web/WebScriptMessageHandler.swift
@@ -234,32 +234,26 @@ extension WebFaceView {
 
     /// Routes the script message to the viewer and handles the response.
     private func routeMessageToViewer(_ message: RequestScriptMessage) {
-
+        
         // notify the host's message delegate of the custom message from the web page
         self.delegate?.faceView(self,
                                 didSendMessage: message.name,
                                 withObject: message.payload,
-                                completion: { (payload, error) in
-
-                                    // transform the bridge error
-                                    let bridgeError = BridgeError.viewer(error?.message ?? "Unknown error occured.")
-
-                                    // V1 Support. Transform the `viewer.qr.scan` reponse paylaod from [String: String]
-                                    // to String.
-                                    if message.version == "1.0.0" && message.name == "viewer.qr.scan" {
-                                        if let newPayload = payload?["data"] {
-                                            self.sendResponse(forRequestMessage: message, payload: newPayload,
-                                                              error: bridgeError)
-                                            return
-                                        }
+                                completion: { result in
+                                    switch result {
+                                    case .success(let payload):
+                                        self.sendResponse(forRequestMessage: message, payload: payload, error: nil)
+                                        return
+                                    case .failure(let error):
+                                        // transform the bridge error
+                                        let bridgeError = BridgeError.viewer(error.message)
+                                        self.sendResponse(forRequestMessage: message,
+                                                          payload: nil,
+                                                          error: bridgeError)
+                                        return
                                     }
-
-                                    self.sendResponse(forRequestMessage: message,
-                                                      payload: payload,
-                                                      error: bridgeError)
-
         })
-
+        
     }
 
     /// Transforms viewer message from protocol V1 to V2.

--- a/BlockV/Face/Vatom View/FaceMessageDelegate.swift
+++ b/BlockV/Face/Vatom View/FaceMessageDelegate.swift
@@ -12,6 +12,94 @@
 import Foundation
 import GenericJSON
 
+/// The protocol types must conform to in order to communinicate with vatom view.
+///
+/// Faces may send custom messages to their underlying viewer to request additional functionality.
+public protocol VatomViewDelegate: class {
+
+    /// Tells the delegate that a face message has been received.
+    ///
+    /// - Parameters:
+    ///   - vatomView: A vatom-view object informing the delegate about the face message.
+    ///   - message: The unique identifier of the message.
+    ///   - object: Companion object which addtional information relevant to the request.
+    ///   - completion: The completion handler to call once the request has been processed. Passed a `Result` type
+    ///         with either the success payload of a face message error.
+    func vatomView(_ vatomView: VatomView,
+                   didRecevieFaceMessage message: String,
+                   withObject object: [String: JSON],
+                   completion: ((Result<JSON, FaceMessageError>) -> Void)?)
+
+    /// Tells the delegate that a face view was selected, or an error was encountered.
+    ///
+    /// A face view is selected as part of the Vatom View Life Cycle (VVLC). There are two scenarios where this will
+    /// happen:
+    /// 1. A `VatomView` instance was created (triggering the VVLC).
+    /// 2. After calling `update(usingVatom:procedure:)` (triggering the VVLC), which resulted in a new Face View being
+    /// selected.
+    ///
+    /// - Parameters:
+    ///   - vatomView: A vatom-view object informing the delegate about the selected face.
+    ///   - result: A `Result` type type containing either the selected face view or an error.
+    func vatomView(_ vatomView: VatomView, didSelectFaceView result: Result<FaceView, VVLCError>)
+
+    /// Tells the delgate that the selected face view has completed loading, or an error was encountered.
+    ///
+    /// - Parameters:
+    ///   - vatomView: A vatom-view object informing the delegate about the selected face completing its load.
+    ///   - result: A `Result` instance with the result of the selected face view's load outcome.
+    func vatomView(_ vatomView: VatomView, didLoadFaceView result: Result<FaceView, VVLCError>)
+
+}
+
+/// This extension contians default and empty implementations of `VatomViewDelegate` methods.
+/// This is the 'Swifty' way to make the methods optional.
+public extension VatomViewDelegate {
+
+    func vatomView(_ vatomView: VatomView,
+                   didRecevieFaceMessage message: String,
+                   withObject object: [String: JSON],
+                   completion: ((Result<JSON, FaceMessageError>) -> Void)?) {
+        // optional method
+    }
+
+    func vatomView(_ vatomView: VatomView, didSelectFaceView result: Result<FaceView, VVLCError>) {
+        // optional method
+    }
+
+    func vatomView(_ vatomView: VatomView, didLoadFaceView result: Result<FaceView, VVLCError>) {
+        // optional method
+    }
+
+}
+
+/// Vatom View Life Cycle error.
+public enum VVLCError: Error, CustomStringConvertible {
+
+    /// Face selection failed.
+    case faceViewSelectionFailed
+    /// A face model was selected but no corresponding face view was registered.
+    case unregisteredFaceViewSelected(_ displayURL: String)
+    /// The face view failed to load.
+    case faceViewLoadFailed
+
+    public var description: String {
+        switch self {
+        case .faceViewSelectionFailed:
+            return "Face Selection Procedure (FSP) did not select a face view."
+        case .unregisteredFaceViewSelected(let url):
+            return """
+            Face Selection Procedure (FSP) selected a face view '\(url)' without the face view being registered.
+            """
+        case .faceViewLoadFailed:
+            return "Face View load failed."
+        }
+    }
+
+}
+
+// MARK: - Face View Delegate
+
 /// Face message error (view bridge).
 public struct FaceMessageError: Error {
     public let message: String
@@ -21,45 +109,8 @@ public struct FaceMessageError: Error {
     }
 }
 
-/// The protocol types must conform to in order to comuninicate with vatom view.
-///
-/// Faces may send messages to their underlying viewer to request additional functionality. As a viewer it is
-/// important that you state which messages you support (by implementing `determinedSupport(forFaceMessages:[Srting])`).
-/// This gives the face an opportunity to adapt it's behaviour.
-public protocol VatomViewDelegate: class {
-
-    /// Completion handler for face messages.
-    ///
-    /// - Parameters:
-    ///   - payload: The JSON payload to be sent back to the Web Face SDK.
-    ///   - error: Error with description if one was encountered.
-    typealias Completion = (_ payload: JSON?, _ error: FaceMessageError?) -> Void
-
-    /// Called when the vatom view receives a message from the face.
-    ///
-    /// - Parameters:
-    ///   - vatomView: The `VatomView` instance which the face message was received from.
-    ///   - message: The unique identifier of the message.
-    ///   - object: Companion object which addtional information relevant to the request.
-    ///   - completion: The completion handler to call once the request has been processed.
-    func vatomView(_ vatomView: VatomView,
-                   didRecevieFaceMessage message: String,
-                   withObject object: [String: JSON],
-                   completion: VatomViewDelegate.Completion?)
-
-}
-
-// MARK: - Face View Delegate
-
 /// The protocol face views must conform to in order to communicate
 protocol FaceViewDelegate: class {
-
-    /// Completion handler for face messages.
-    ///
-    /// - Parameters:
-    ///   - payload: The JSON payload to be sent back to the Web Face View.
-    ///   - error: Error with description if one was encountered.
-    typealias Completion = (_ payload: JSON?, _ error: FaceMessageError?) -> Void
 
     /// Called when the vatom view receives a message from the face.
     ///
@@ -71,7 +122,7 @@ protocol FaceViewDelegate: class {
     func faceView(_ faceView: FaceView,
                   didSendMessage message: String,
                   withObject object: [String: JSON],
-                  completion: FaceViewDelegate.Completion?)
+                  completion: ((Result<JSON, FaceMessageError>) -> Void)?)
 
 }
 
@@ -83,7 +134,7 @@ extension VatomView: FaceViewDelegate {
     func faceView(_ faceView: FaceView,
                   didSendMessage message: String,
                   withObject object: [String: JSON],
-                  completion: ((JSON?, FaceMessageError?) -> Void)?) {
+                  completion: ((Result<JSON, FaceMessageError>) -> Void)?) {
 
         // forward the message to the vatom view delegate
         self.vatomViewDelegate?.vatomView(self,

--- a/Example/BlockV/Controllers/Inventory/TappedVatomViewController.swift
+++ b/Example/BlockV/Controllers/Inventory/TappedVatomViewController.swift
@@ -150,12 +150,14 @@ class TappedVatomViewController: UIViewController {
 // MARK: - Vatom View Delegate
 
 extension TappedVatomViewController: VatomViewDelegate {
-    
+
     func vatomView(_ vatomView: VatomView,
                    didRecevieFaceMessage message: String,
-                   withObject object: [String : JSON],
-                   completion: ((JSON?, FaceMessageError?) -> Void)?) {
-        print("Message: \(message)")
+                   withObject object: [String: JSON],
+                   completion: ((Result<JSON, FaceMessageError>) -> Void)?) {
+     
+        print("Handle face message: \(message)")
+
     }
-    
+
 }

--- a/Example/BlockV/Views/LiveVatomView.swift
+++ b/Example/BlockV/Views/LiveVatomView.swift
@@ -36,8 +36,8 @@ class LiveVatomView: VatomView {
         commonInit()
     }
 
-    override init(vatom: VatomModel, procedure: @escaping FaceSelectionProcedure) {
-        super.init(vatom: vatom, procedure: procedure)
+    override init(vatom: VatomModel, procedure: @escaping FaceSelectionProcedure, delegate: VatomViewDelegate? = nil) {
+        super.init(vatom: vatom, procedure: procedure, delegate: delegate)
         commonInit()
     }
 


### PR DESCRIPTION
1. Expand `VatomViewDelegate` to include two new methods:

- `vatomView(:didSelectFaceView:)`
- `vatomView(:didLoadFaceView:)`

these methods allow a vatom-view host to keep better informed about the Vatom View Lifecycle (VVLC).

2. All `VatomViewDelegate` methods now use the `Result` type in their completion closure. This is in preparation for the Swift 5 release.