### PR TITLE
Core: Fix - OAuth V2

### DIFF
--- a/BlockV/Core/Helpers/OAuth/AuthorizationServer.swift
+++ b/BlockV/Core/Helpers/OAuth/AuthorizationServer.swift
@@ -127,18 +127,8 @@ public final class AuthorizationServer {
         // perform request
         BLOCKv.client.request(endpoint) { result in
             switch result {
-            case .success(let model):
-                //FIXME: Temporary converstion between temporary token model
-                let oauthTokenExchangeModel = OAuthTokenExchangeModel(accessToken: model.payload.accessToken.token,
-                                                                      refreshToken: model.payload.refreshToken.token,
-                                                                      tokenType: model.payload.accessToken.tokenType,
-                                                                      expriesIn: nil,
-                                                                      scope: nil)
-
-                completion(.success(oauthTokenExchangeModel))
-
-            case .failure(let error):
-                completion(.failure(error))
+            case .success(let model): completion(.success(model))
+            case .failure(let error): completion(.failure(error))
             }
         }
 

--- a/BlockV/Core/Network/Models/OAuthTokenExchangeModel.swift
+++ b/BlockV/Core/Network/Models/OAuthTokenExchangeModel.swift
@@ -11,24 +11,12 @@
 
 import Foundation
 
-public struct TemporaryOAuthTokenExchangeModel: Decodable, Equatable {
-
-    let accessToken: BVToken
-    let refreshToken: BVToken
-    
-    enum CodingKeys: String, CodingKey {
-        case accessToken    = "access_token"
-        case refreshToken   = "refresh_token"
-    }
-    
-}
-
 public struct OAuthTokenExchangeModel: Decodable, Equatable {
     let accessToken: String
     let refreshToken: String
-    let tokenType: String? //FIXME: Make non-optional when server is updated
-    let expriesIn: Double? //FIXME: Make non-optional when server is updated
-    let scope: String? //FIXME: Make non-optional when server is updated
+    let tokenType: String
+    let expriesIn: Double
+    let scope: String
 
     enum CodingKeys: String, CodingKey {
         case accessToken    = "access_token"

--- a/BlockV/Core/Network/Stack/API+TypedResponses.swift
+++ b/BlockV/Core/Network/Stack/API+TypedResponses.swift
@@ -24,7 +24,7 @@ extension API {
         ///
         /// - Returns: Constructed endpoint generic over response model that may be passed to a request.
         static func tokenExchange(grantType: String, clientID: String, code: String, redirectURI: String)
-            -> Endpoint<BaseModel<TemporaryOAuthTokenExchangeModel>> {
+            -> Endpoint<OAuthTokenExchangeModel> {
                 return API.Generic.token(grantType: grantType, clientID: clientID, code: code, redirectURI: redirectURI)
         }
 

--- a/BlockV/Core/Network/Stack/Client.swift
+++ b/BlockV/Core/Network/Stack/Client.swift
@@ -219,14 +219,10 @@ final class Client: ClientProtocol {
                     // inject token into session's oauth handler
                     self.oauthHandler.set(accessToken: model.payload.accessToken.token,
                                           refreshToken: model.payload.refreshToken.token)
-                } else if let model = val as? BaseModel<OAuthTokenExchangeModel> {
+                } else if let model = val as? OAuthTokenExchangeModel {
                     // inject token into session's oauth handler
-                    self.oauthHandler.set(accessToken: model.payload.accessToken,
-                                          refreshToken: model.payload.refreshToken)
-                } else if let model =  val as? BaseModel<TemporaryOAuthTokenExchangeModel> { //FIXME: Remove this!
-                    // inject token into session's oauth handler
-                    self.oauthHandler.set(accessToken: model.payload.accessToken.token,
-                                          refreshToken: model.payload.refreshToken.token)
+                    self.oauthHandler.set(accessToken: model.accessToken,
+                                          refreshToken: model.refreshToken)
                 }
 
                 completion(.success(val))

--- a/BlockV/Core/Requests/BLOCKv+AuthRequests.swift
+++ b/BlockV/Core/Requests/BLOCKv+AuthRequests.swift
@@ -62,7 +62,7 @@ extension BLOCKv {
                             // pull back to main queue
                             DispatchQueue.main.async {
 
-                                let refreshToken = BVToken(token: tokens.refreshToken, tokenType: tokens.tokenType!)
+                                let refreshToken = BVToken(token: tokens.refreshToken, tokenType: tokens.tokenType)
                                 // persist refresh token and credential
                                 CredentialStore.saveRefreshToken(refreshToken)
                                 CredentialStore.saveAssetProviders(model.payload.assetProviders)


### PR DESCRIPTION
This PR removes the `TemporaryOAuthTokenExchangeModel` and replaces it with `OAuthTokenExchangeModel` which aligns with the API change (made to meet the OAuth spec).