### PR TITLE
Core: Fix - Vatom view reuse pool

### DIFF
--- a/BlockV/Face/Vatom View/DefaultErrorView.swift
+++ b/BlockV/Face/Vatom View/DefaultErrorView.swift
@@ -82,7 +82,7 @@ internal final class DefaultErrorView: UIView & VatomViewError {
         activatedImageView.rightAnchor.constraint(equalTo: self.rightAnchor).isActive = true
         activatedImageView.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
         activatedImageView.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
-        
+
         ImagePipeline.Configuration.isAnimatedImageDataEnabled = true
 
     }
@@ -132,7 +132,7 @@ internal final class DefaultErrorView: UIView & VatomViewError {
 }
 
 extension DefaultErrorView {
-    
+
     /// Size of the bounds of the view in pixels.
     public var pixelSize: CGSize {
         get {
@@ -140,5 +140,5 @@ extension DefaultErrorView {
                           height: self.bounds.size.height * UIScreen.main.scale)
         }
     }
-    
+
 }

--- a/BlockV/Face/Vatom View/VatomView.swift
+++ b/BlockV/Face/Vatom View/VatomView.swift
@@ -273,7 +273,7 @@ open class VatomView: UIView {
         errorView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
 
         self.state = .loading
-        
+
     }
 
     // MARK: - State Management
@@ -381,7 +381,7 @@ open class VatomView: UIView {
 //        printBV(info: "Face model changed - Replacing face view.")
 
         // 2. check if the face model has not changed
-            
+
         if (vatom.props.templateVariationID == oldVatom?.props.templateVariationID) &&
             (newSelectedFaceModel == self.selectedFaceModel) {
 
@@ -413,7 +413,7 @@ open class VatomView: UIView {
             } else {
                 faceViewType = roster[newSelectedFaceModel.properties.displayURL]
             }
-            
+
             guard let viewType = faceViewType else {
                 // viewer developer MUST have registered the face view with the face registry
                 self.vatomViewDelegate?.vatomView(self, didSelectFaceView: .failure(VVLCError.faceViewSelectionFailed))
@@ -436,10 +436,9 @@ open class VatomView: UIView {
             self.replaceFaceView(with: newSelectedFaceView)
             // inform delegate
             self.vatomViewDelegate?.vatomView(self, didSelectFaceView: .success(newSelectedFaceView))
-            
+
         }
 
-        
     }
 
     /// Replaces the current face view (if any) with the specified face view and starts the FVLC.

--- a/BlockV/Face/Vatom View/VatomView.swift
+++ b/BlockV/Face/Vatom View/VatomView.swift
@@ -427,7 +427,6 @@ open class VatomView: UIView {
 
 //            printBV(info: "Face view for face model: \(faceViewType)")
 
-            //let selectedFaceView: FaceView = ImageFaceView(vatom: vatom, faceModel: selectedFace, host: self)
             let newSelectedFaceView: FaceView = viewType.init(vatom: vatom,
                                                               faceModel: newSelectedFaceModel)
             newSelectedFaceView.delegate = self


### PR DESCRIPTION
Fixes and issue where a load closure could affect the state of a vatom-view even after the vatom-view's vatom had changed..