### PR TITLE
Face: Fix - Cache key to include target size

### DIFF
--- a/BlockV/Face/Extensions/Nuke+AnimatedImage.swift
+++ b/BlockV/Face/Extensions/Nuke+AnimatedImage.swift
@@ -33,3 +33,20 @@ extension FLAnimatedImageView {
         }
     }
 }
+
+
+extension ImageRequest {
+    
+    /// Generates a cache key based on the specified arguments.
+    func generateCacheKey(url: URL, targetSize: CGSize? = nil) -> Int {
+        // create a hash for the cacheKey
+        var hasher = Hasher()
+        hasher.combine(url)
+        if let targetSize = targetSize {
+            hasher.combine(targetSize.width)
+            hasher.combine(targetSize.height)
+        }
+        return hasher.finalize()
+    }
+    
+}

--- a/BlockV/Face/Face Views/Image Layered/ImageLayeredFaceView.swift
+++ b/BlockV/Face/Face Views/Image Layered/ImageLayeredFaceView.swift
@@ -271,8 +271,13 @@ class ImageLayeredFaceView: FaceView {
             var request = ImageRequest(url: encodeURL,
                                        targetSize: pixelSize,
                                        contentMode: .aspectFit)
-            // use unencoded url as cache key
-            request.cacheKey = resourceModel.url
+            // create a hash for the cacheKey
+            var hasher = Hasher()
+            hasher.combine(resourceModel.url)
+            hasher.combine(pixelSize.width)
+            hasher.combine(pixelSize.height)
+            // set cache key
+            request.cacheKey = hasher.finalize()
 
             // load image (auto cancel previous)
             Nuke.loadImage(with: request, into: self.baseLayer) { (_, error) in

--- a/BlockV/Face/Face Views/Image Layered/ImageLayeredFaceView.swift
+++ b/BlockV/Face/Face Views/Image Layered/ImageLayeredFaceView.swift
@@ -271,13 +271,9 @@ class ImageLayeredFaceView: FaceView {
             var request = ImageRequest(url: encodeURL,
                                        targetSize: pixelSize,
                                        contentMode: .aspectFit)
-            // create a hash for the cacheKey
-            var hasher = Hasher()
-            hasher.combine(resourceModel.url)
-            hasher.combine(pixelSize.width)
-            hasher.combine(pixelSize.height)
+
             // set cache key
-            request.cacheKey = hasher.finalize()
+            request.cacheKey = request.generateCacheKey(url: resourceModel.url, targetSize: pixelSize)
 
             // load image (auto cancel previous)
             Nuke.loadImage(with: request, into: self.baseLayer) { (_, error) in

--- a/BlockV/Face/Face Views/Image Policy/ImagePolicyFaceView.swift
+++ b/BlockV/Face/Face Views/Image Policy/ImagePolicyFaceView.swift
@@ -214,8 +214,14 @@ class ImagePolicyFaceView: FaceView {
             var request = ImageRequest(url: encodeURL,
                                        targetSize: pixelSize,
                                        contentMode: .aspectFit)
-            // use unencoded url as cache key
-            request.cacheKey = resourceModel.url
+            // create a hash for the cacheKey
+            var hasher = Hasher()
+            hasher.combine(resourceModel.url)
+            hasher.combine(pixelSize.width)
+            hasher.combine(pixelSize.height)
+            // set cache key
+            request.cacheKey = hasher.finalize()
+            
             // load image (automatically handles reuse)
             Nuke.loadImage(with: request, into: self.animatedImageView) { (_, error) in
                 self.isLoaded = true

--- a/BlockV/Face/Face Views/Image Policy/ImagePolicyFaceView.swift
+++ b/BlockV/Face/Face Views/Image Policy/ImagePolicyFaceView.swift
@@ -59,7 +59,7 @@ class ImagePolicyFaceView: FaceView {
         }
 
         super.init(vatom: vatom, faceModel: faceModel)
-        
+
         // enable animated images
         ImagePipeline.Configuration.isAnimatedImageDataEnabled = true
 
@@ -104,7 +104,7 @@ class ImagePolicyFaceView: FaceView {
         if self.vatom.id == vatom.id {
             // replace vatom, update UI
             self.vatom = vatom
-            
+
         } else {
             // replace vatom, reset and update UI
             self.vatom = vatom
@@ -214,14 +214,10 @@ class ImagePolicyFaceView: FaceView {
             var request = ImageRequest(url: encodeURL,
                                        targetSize: pixelSize,
                                        contentMode: .aspectFit)
-            // create a hash for the cacheKey
-            var hasher = Hasher()
-            hasher.combine(resourceModel.url)
-            hasher.combine(pixelSize.width)
-            hasher.combine(pixelSize.height)
+
             // set cache key
-            request.cacheKey = hasher.finalize()
-            
+            request.cacheKey = request.generateCacheKey(url: resourceModel.url, targetSize: pixelSize)
+
             // load image (automatically handles reuse)
             Nuke.loadImage(with: request, into: self.animatedImageView) { (_, error) in
                 self.isLoaded = true

--- a/BlockV/Face/Face Views/Image Progress/ImageProgressFaceView.swift
+++ b/BlockV/Face/Face Views/Image Progress/ImageProgressFaceView.swift
@@ -288,16 +288,28 @@ class ImageProgressFaceView: FaceView {
             dispatchGroup.enter()
 
             var requestEmpty = ImageRequest(url: encodedEmptyURL)
-            // use unencoded url as cache key
-            requestEmpty.cacheKey = emptyImageResource.url
+            // create a hash for the cacheKey
+            var hasherEmpty = Hasher()
+            hasherEmpty.combine(emptyImageResource.url)
+            hasherEmpty.combine(pixelSize.width)
+            hasherEmpty.combine(pixelSize.height)
+            // set cache key
+            requestEmpty.cacheKey = hasherEmpty.finalize()
+            
             // load image (automatically handles reuse)
             Nuke.loadImage(with: requestEmpty, into: self.emptyImageView) { (_, _) in
                 self.dispatchGroup.leave()
             }
 
             var requestFull = ImageRequest(url: encodedFullURL)
-            // use unencoded url as cache key
-            requestFull.cacheKey = fullImageResource.url
+            // create a hash for the cacheKey
+            var hasherFull = Hasher()
+            hasherFull.combine(fullImageResource.url)
+            hasherFull.combine(pixelSize.width)
+            hasherFull.combine(pixelSize.height)
+            // set cache key
+            requestFull.cacheKey = hasherFull.finalize()
+            
             // load image (automatically handles reuse)
             Nuke.loadImage(with: requestFull, into: self.fullImageView) { (_, _) in
                 self.dispatchGroup.leave()

--- a/BlockV/Face/Face Views/Image Progress/ImageProgressFaceView.swift
+++ b/BlockV/Face/Face Views/Image Progress/ImageProgressFaceView.swift
@@ -288,28 +288,18 @@ class ImageProgressFaceView: FaceView {
             dispatchGroup.enter()
 
             var requestEmpty = ImageRequest(url: encodedEmptyURL)
-            // create a hash for the cacheKey
-            var hasherEmpty = Hasher()
-            hasherEmpty.combine(emptyImageResource.url)
-            hasherEmpty.combine(pixelSize.width)
-            hasherEmpty.combine(pixelSize.height)
             // set cache key
-            requestEmpty.cacheKey = hasherEmpty.finalize()
-            
+            requestEmpty.cacheKey = requestEmpty.generateCacheKey(url: emptyImageResource.url, targetSize: pixelSize)
+
             // load image (automatically handles reuse)
             Nuke.loadImage(with: requestEmpty, into: self.emptyImageView) { (_, _) in
                 self.dispatchGroup.leave()
             }
 
             var requestFull = ImageRequest(url: encodedFullURL)
-            // create a hash for the cacheKey
-            var hasherFull = Hasher()
-            hasherFull.combine(fullImageResource.url)
-            hasherFull.combine(pixelSize.width)
-            hasherFull.combine(pixelSize.height)
             // set cache key
-            requestFull.cacheKey = hasherFull.finalize()
-            
+            requestFull.cacheKey = requestFull.generateCacheKey(url: fullImageResource.url, targetSize: pixelSize)
+
             // load image (automatically handles reuse)
             Nuke.loadImage(with: requestFull, into: self.fullImageView) { (_, _) in
                 self.dispatchGroup.leave()

--- a/BlockV/Face/Face Views/Image/ImageFaceView.swift
+++ b/BlockV/Face/Face Views/Image/ImageFaceView.swift
@@ -215,9 +215,14 @@ class ImageFaceView: FaceView {
                                        targetSize: pixelSize,
                                        contentMode: nukeContentMode)
             
-            // use unencoded url as cache key
-            request.cacheKey = resourceModel.url
-
+            // create a hash for the cacheKey
+            var hasher = Hasher()
+            hasher.combine(resourceModel.url)
+            hasher.combine(pixelSize.width)
+            hasher.combine(pixelSize.height)
+            // set cache key
+            request.cacheKey = hasher.finalize()
+            
             /*
              Nuke's `loadImage` cancels any exisitng requests and nils out the old image. This takes care of the reuse-pool
              use case where the same face view is used to display a vatom of the same template variation.

--- a/BlockV/Face/Face Views/Image/ImageFaceView.swift
+++ b/BlockV/Face/Face Views/Image/ImageFaceView.swift
@@ -50,7 +50,7 @@ class ImageFaceView: FaceView {
         /// ### Legacy Support
         /// The first resource name in the resources array (if present) is used in place of the activate image.
         init(_ faceModel: FaceModel) {
-            
+
             // enable animated images
             ImagePipeline.Configuration.isAnimatedImageDataEnabled = true
 
@@ -117,7 +117,7 @@ class ImageFaceView: FaceView {
     private func updateContentMode() {
         self.animatedImageView.contentMode = configuredContentMode
     }
-    
+
     var configuredContentMode: UIView.ContentMode {
         // check face config
         switch config.scale {
@@ -190,7 +190,7 @@ class ImageFaceView: FaceView {
     }
 
     // MARK: - Resources
-    
+
     var nukeContentMode: ImageDecompressor.ContentMode {
         // check face config, convert to nuke content mode
         switch config.scale {
@@ -214,15 +214,10 @@ class ImageFaceView: FaceView {
             var request = ImageRequest(url: encodeURL,
                                        targetSize: pixelSize,
                                        contentMode: nukeContentMode)
-            
-            // create a hash for the cacheKey
-            var hasher = Hasher()
-            hasher.combine(resourceModel.url)
-            hasher.combine(pixelSize.width)
-            hasher.combine(pixelSize.height)
+
             // set cache key
-            request.cacheKey = hasher.finalize()
-            
+            request.cacheKey = request.generateCacheKey(url: resourceModel.url, targetSize: pixelSize)
+
             /*
              Nuke's `loadImage` cancels any exisitng requests and nils out the old image. This takes care of the reuse-pool
              use case where the same face view is used to display a vatom of the same template variation.

--- a/BlockV/Face/Vatom View/DefaultErrorView.swift
+++ b/BlockV/Face/Vatom View/DefaultErrorView.swift
@@ -127,17 +127,10 @@ internal final class DefaultErrorView: BoundedView & VatomViewError {
         // create request
         var request = ImageRequest(url: encodeURL,
                                    targetSize: pixelSize,
-                                   contentMode: .aspectFit)
+                                   contentMode: .aspectFill)
         
-        // create a hash for the cacheKey
-        var hasher = Hasher()
-        hasher.combine(resourceModel.url)
-        hasher.combine(pixelSize.width)
-        hasher.combine(pixelSize.height)
         // set cache key
-        request.cacheKey = hasher.finalize()
-    
-        print("CacheKey", request.cacheKey)
+        request.cacheKey = request.generateCacheKey(url: resourceModel.url, targetSize: pixelSize)
         
         // load image
         Nuke.loadImage(with: request, into: activatedImageView) { [weak self] (_, _) in
@@ -161,7 +154,6 @@ extension DefaultErrorView {
     }
 
 }
-
 
 /// This view class provides a convenient way to know when the bounds of a view have been set.
 class BoundedView: UIView {

--- a/BlockV/Face/Vatom View/DefaultErrorView.swift
+++ b/BlockV/Face/Vatom View/DefaultErrorView.swift
@@ -18,7 +18,7 @@ import Nuke
 /// Shows:
 /// 1. vAtoms activated image.
 /// 2. Warning trigangle (that is tappable).
-internal final class DefaultErrorView: UIView & VatomViewError {
+internal final class DefaultErrorView: BoundedView & VatomViewError {
 
     // MARK: - Debug
 
@@ -59,7 +59,8 @@ internal final class DefaultErrorView: UIView & VatomViewError {
 
     var vatom: VatomModel? {
         didSet {
-            self.loadResources()
+            // raise flag that layout is needed on the bounds are known
+            self.requiresBoundsBasedLayout = true
         }
     }
 
@@ -90,6 +91,12 @@ internal final class DefaultErrorView: UIView & VatomViewError {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    override func layoutWithKnownBounds() {
+        super.layoutWithKnownBounds()
+        // only at this point is the frame know, and therefore the target size is valid
+        loadResources()
+    }
 
     // MARK: - Logic
 
@@ -97,6 +104,7 @@ internal final class DefaultErrorView: UIView & VatomViewError {
     ///
     /// The error view uses the activated image as a placeholder.
     private func loadResources() {
+        print(#function, self.bounds)
 
         activityIndicator.startAnimating()
 
@@ -120,9 +128,18 @@ internal final class DefaultErrorView: UIView & VatomViewError {
         var request = ImageRequest(url: encodeURL,
                                    targetSize: pixelSize,
                                    contentMode: .aspectFit)
-        // use unencoded url as cache key
-        request.cacheKey = resourceModel.url
-        // load the image (reuse pool is automatically handled)
+        
+        // create a hash for the cacheKey
+        var hasher = Hasher()
+        hasher.combine(resourceModel.url)
+        hasher.combine(pixelSize.width)
+        hasher.combine(pixelSize.height)
+        // set cache key
+        request.cacheKey = hasher.finalize()
+    
+        print("CacheKey", request.cacheKey)
+        
+        // load image
         Nuke.loadImage(with: request, into: activatedImageView) { [weak self] (_, _) in
             self?.activityIndicator.stopAnimating()
         }
@@ -134,11 +151,50 @@ internal final class DefaultErrorView: UIView & VatomViewError {
 extension DefaultErrorView {
 
     /// Size of the bounds of the view in pixels.
-    public var pixelSize: CGSize {
+    ///
+    /// Be sure to call this property *after* the view has been layed out.
+    var pixelSize: CGSize {
         get {
             return CGSize(width: self.bounds.size.width * UIScreen.main.scale,
                           height: self.bounds.size.height * UIScreen.main.scale)
         }
     }
 
+}
+
+
+/// This view class provides a convenient way to know when the bounds of a view have been set.
+class BoundedView: UIView {
+    
+    /// Setting this value to `true` will trigger a subview layout and ensure that `layoutWithKnowBounds()` is called
+    /// thereafter.
+    var requiresBoundsBasedLayout = false {
+        didSet {
+            if requiresBoundsBasedLayout {
+                // trigger a new layout cycle
+                hasCompletedLayoutSubviews = false
+                self.setNeedsLayout()
+            }
+        }
+    }
+    
+    /// Boolean value indicating whether a layout pass has been completed since `requiresBoundsBasedLayout`
+    private var hasCompletedLayoutSubviews = false
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        if requiresBoundsBasedLayout && !hasCompletedLayoutSubviews {
+            layoutWithKnownBounds()
+            hasCompletedLayoutSubviews = true
+            requiresBoundsBasedLayout = false
+        }
+        
+    }
+    
+    /// Called only after `layoutSubviews` has been called (i.e. bounds are set).
+    func layoutWithKnownBounds() {
+        // subclass should override
+    }
+    
 }


### PR DESCRIPTION
This PR:

1. Adjusts the cache key to include the target size to ensure that when Nuke reaches for it's in-memory cache, it fetches images which also meet the target size criteria. Note: Nuke's `cacheKey` property on `ImageRequest` is used as the in-memory caching key and does not affect on disk caching.

2. Creates and abstract class `BoundedView` which has a function `layoutWithKnownBounds()` that is called once the bounds of self are known. This is important when the view is constrained using auto-layout and the bounds are only known after `layoutSubviews()` has been called.