### PR TITLE
Core: Fix - Inventory region max page

### DIFF
--- a/BlockV/Core/Data Pool/Regions/InventoryRegion.swift
+++ b/BlockV/Core/Data Pool/Regions/InventoryRegion.swift
@@ -211,15 +211,15 @@ extension InventoryRegion {
                         if (items.count == 0) || (self.proccessedPageCount > self.maxReasonablePages) {
                             shouldRecurse = false
                         }
+                        
+                        // increment page count
+                        self.proccessedPageCount += 1
 
                         return resolver.fulfill(newIds)
 
                     }
                 }
 
-            }.ensure {
-                // increment page count
-                self.proccessedPageCount += 1
             }
 
             promises.append(promise)


### PR DESCRIPTION
Fix an issue where the `processedPageCount` did not increment correctly.