### PR TITLE
Fix: Linter

### DIFF
--- a/BlockV/Core/Data Pool/Regions/InventoryRegion.swift
+++ b/BlockV/Core/Data Pool/Regions/InventoryRegion.swift
@@ -202,10 +202,10 @@ extension InventoryRegion {
         // tracking flag
         var shouldRecurse = true
 
-        for i in range {
+        for page in range {
 
             // build raw request
-            let endpoint: Endpoint<Void> = API.Generic.getInventory(parentID: "*", page: i, limit: pageSize)
+            let endpoint: Endpoint<Void> = API.Generic.getInventory(parentID: "*", page: page, limit: pageSize)
 
             // exectute request
             let promise = BLOCKv.client.requestJSON(endpoint).then(on: .global(qos: .userInitiated)) { json -> Promise<[String]?> in

--- a/BlockV/Core/Network/Models/Package/Action/ActionModel+Descriptor.swift
+++ b/BlockV/Core/Network/Models/Package/Action/ActionModel+Descriptor.swift
@@ -11,6 +11,8 @@
 
 import Foundation
 
+//swiftlint:disable identifier_name
+
 extension ActionModel: Descriptable {
     
     init(from descriptor: [String: Any]) throws {

--- a/BlockV/Core/Network/Models/Package/Face/FaceModel+Descriptable.swift
+++ b/BlockV/Core/Network/Models/Package/Face/FaceModel+Descriptable.swift
@@ -12,6 +12,8 @@
 import Foundation
 import GenericJSON
 
+//swiftlint:disable identifier_name
+
 extension FaceModel: Descriptable {
     
     init(from descriptor: [String: Any]) throws {

--- a/BlockV/Core/Network/Models/Package/Vatom/VatomModel+Descriptor.swift
+++ b/BlockV/Core/Network/Models/Package/Vatom/VatomModel+Descriptor.swift
@@ -12,6 +12,8 @@
 import Foundation
 import GenericJSON
 
+//swiftlint:disable identifier_name
+
 protocol Descriptable {
     init(from descriptor: [String: Any]) throws
 }

--- a/BlockV/Face/Face Views/Web/Face Bridge/CoreBridgeV2.swift
+++ b/BlockV/Face/Face Views/Web/Face Bridge/CoreBridgeV2.swift
@@ -12,10 +12,12 @@
 import Foundation
 import GenericJSON
 
+//FIXME: Remove temporary disable type_body_length
+
 /// Core Bridge (Version 2.0.0)
 ///
 /// Bridges into the Core module.
-class CoreBridgeV2: CoreBridge {
+class CoreBridgeV2: CoreBridge { //swiftlint:disable:this type_body_length
 
     // MARK: - Enums
 

--- a/Example/.swiftlint.yml
+++ b/Example/.swiftlint.yml
@@ -12,6 +12,7 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Pods
 
 identifier_name:
+  allowed_symbols: "_"
   excluded: # excluded via string array
     - id
 nesting:


### PR DESCRIPTION
Add `//swiftlint:disable identifier_name` to file due to a [bug](https://github.com/realm/SwiftLint/issues/1762) in Switlint preventing underscores to be used in identifier names.