### PR TITLE
Face: Fix - Face view throwing initialiser

### DIFF
--- a/BlockV/Face/Face Views/FaceView.swift
+++ b/BlockV/Face/Face Views/FaceView.swift
@@ -101,7 +101,7 @@ public protocol FaceViewLifecycle: class {
 open class BaseFaceView: BoundedView {
 
     /// Vatom to render.
-    public internal(set) var vatom: VatomModel
+    public var vatom: VatomModel
 
     /// Face model to render.
     public internal(set) var faceModel: FaceModel
@@ -113,7 +113,7 @@ open class BaseFaceView: BoundedView {
     ///
     /// Use the initializer purely to configure the face view. Use the `load` lifecycle method to begin heavy operations
     /// to update the state of the face view, e.g. downloading resources.
-    public required init(vatom: VatomModel, faceModel: FaceModel) {
+    public required init(vatom: VatomModel, faceModel: FaceModel) throws {
         self.vatom = vatom
         self.faceModel = faceModel
         super.init(frame: CGRect(x: 0, y: 0, width: 50, height: 50))

--- a/BlockV/Face/Face Views/Image Layered/ImageLayeredFaceView.swift
+++ b/BlockV/Face/Face Views/Image Layered/ImageLayeredFaceView.swift
@@ -85,11 +85,11 @@ class ImageLayeredFaceView: FaceView {
     private let config: Config
 
     // MARK: - Init
-    required init(vatom: VatomModel, faceModel: FaceModel) {
+    required init(vatom: VatomModel, faceModel: FaceModel) throws {
         // init face config
         self.config = Config(faceModel)
 
-        super.init(vatom: vatom, faceModel: faceModel)
+        try super.init(vatom: vatom, faceModel: faceModel)
 
         self.addSubview(baseLayer)
 

--- a/BlockV/Face/Face Views/Image Policy/ImagePolicyFaceView.swift
+++ b/BlockV/Face/Face Views/Image Policy/ImagePolicyFaceView.swift
@@ -48,7 +48,7 @@ class ImagePolicyFaceView: FaceView {
 
     // MARK: - Initialization
 
-    required init(vatom: VatomModel, faceModel: FaceModel) {
+    required init(vatom: VatomModel, faceModel: FaceModel) throws {
 
         // init face config (or legacy private section) fallback on default values
         if let config = faceModel.properties.config {
@@ -59,7 +59,7 @@ class ImagePolicyFaceView: FaceView {
             self.config = Config() // default values
         }
 
-        super.init(vatom: vatom, faceModel: faceModel)
+        try super.init(vatom: vatom, faceModel: faceModel)
 
         // enable animated images
         ImagePipeline.Configuration.isAnimatedImageDataEnabled = true

--- a/BlockV/Face/Face Views/Image Policy/ImagePolicyFaceView.swift
+++ b/BlockV/Face/Face Views/Image Policy/ImagePolicyFaceView.swift
@@ -168,30 +168,13 @@ class ImagePolicyFaceView: FaceView {
                 }
 
             } else if let policy = policy as? Config.FieldLookup {
-
-                // create key path and split into head and tail
-                guard let component = KeyPath(policy.field).headAndTail() else { continue }
-
-                var vatomValue: JSON?
-                // check container
-                if component.head == "private" {
-                    // current value on the vatom
-                    vatomValue = self.vatom.private?[keyPath: component.tail.path]
-                } else if component.head == "vAtom::vAtomType" {
-                    //TODO: Create a keypath-to-keypath look up
-                    if component.tail.path == "cloning_score" {
-                        vatomValue = try? JSON(self.vatom.props.cloningScore)
-                    } else if component.tail.path == "num_direct_clones" {
-                        vatomValue = try? JSON(self.vatom.props.numberDirectClones)
+                
+                if let vatomValue = self.vatom.valueForKeyPath(keypath: policy.field) {
+                    if vatomValue == policy.value {
+                        // update image
+                        //print(">>:: vAtom Value: \(vatomValue) | Policy Value: \(policy.value)\n")
+                        return policy.resourceName
                     }
-                }
-
-                guard let value = vatomValue else { continue }
-
-                if value == policy.value {
-                    // update image
-                    //print(">>:: vAtom Value: \(vatomValue) | Policy Value: \(policy.value)\n")
-                    return policy.resourceName
                 }
 
             } else if policy is Config.Fallback {

--- a/BlockV/Face/Face Views/Image Progress/ImageProgressFaceView.swift
+++ b/BlockV/Face/Face Views/Image Progress/ImageProgressFaceView.swift
@@ -109,7 +109,7 @@ class ImageProgressFaceView: FaceView {
 
     // MARK: - Initialization
 
-    required init(vatom: VatomModel, faceModel: FaceModel) {
+    required init(vatom: VatomModel, faceModel: FaceModel) throws {
 
         // init face config (or legacy private section) fallback on default values
 
@@ -121,7 +121,7 @@ class ImageProgressFaceView: FaceView {
             self.config = Config() // default values
         }
 
-        super.init(vatom: vatom, faceModel: faceModel)
+        try super.init(vatom: vatom, faceModel: faceModel)
 
         self.addSubview(emptyImageView)
         self.addSubview(fullImageView)

--- a/BlockV/Face/Face Views/Image/ImageFaceView.swift
+++ b/BlockV/Face/Face Views/Image/ImageFaceView.swift
@@ -83,12 +83,12 @@ class ImageFaceView: FaceView {
 
     // MARK: - Initialization
 
-    required init(vatom: VatomModel, faceModel: FaceModel) {
+    required init(vatom: VatomModel, faceModel: FaceModel) throws {
 
         // init face config
         self.config = Config(faceModel)
 
-        super.init(vatom: vatom, faceModel: faceModel)
+        try super.init(vatom: vatom, faceModel: faceModel)
 
         // add image view
         self.addSubview(animatedImageView)

--- a/BlockV/Face/Face Views/Web/WebFaceView.swift
+++ b/BlockV/Face/Face Views/Web/WebFaceView.swift
@@ -69,8 +69,8 @@ class WebFaceView: FaceView {
 
     // MARK: - Initialization
 
-    required init(vatom: VatomModel, faceModel: FaceModel) {
-        super.init(vatom: vatom, faceModel: faceModel)
+    required init(vatom: VatomModel, faceModel: FaceModel) throws {
+        try super.init(vatom: vatom, faceModel: faceModel)
 
         self.addSubview(webView)
     }

--- a/BlockV/Face/Vatom View/VatomView.swift
+++ b/BlockV/Face/Vatom View/VatomView.swift
@@ -454,7 +454,7 @@ open class VatomView: UIView {
 
         }
 
-        let newSelectedFaceView: FaceView = viewType.init(vatom: vatom, faceModel: faceModel)
+        let newSelectedFaceView: FaceView = try viewType.init(vatom: vatom, faceModel: faceModel)
         return newSelectedFaceView
 
     }


### PR DESCRIPTION
Update face view to use a throwing initialiser. This is useful when the face config is a prerequisite for the face's initialisation (and no sensible defaults can be used, e.g. SpriteSheet face view).