### PR TITLE
Core: Fix - Preemptive updates

### DIFF
--- a/BlockV/Core/Data Pool/Helpers/Vatom+PreemptiveActions.swift
+++ b/BlockV/Core/Data Pool/Helpers/Vatom+PreemptiveActions.swift
@@ -11,10 +11,14 @@
 
 import Foundation
 
+//TODO: 1. Preemptive updates should be distributed to all regions.
+//TODO: 2. Regions' should be able to opt into preemptive updates.
+
 /// Extends VatomModel with common vatom actions available on owned vatoms.
 ///
-/// All actions are *preemptive* where possible. That is, data pool is updated locally before the network request is
-/// made performing the action on the server.
+/// Actions are *preemptive* where possible. That is, data pool is updated locally before the network request is
+/// made performing the action on the server. Preemptive updates are always applied to the Inventory Region. Pickup and Drop preemtive updates
+/// are also applied to the GeoPos region.
 extension VatomModel {
 
     // MARK: - Common Actions
@@ -131,17 +135,20 @@ extension VatomModel {
             ]
         ]
 
-        // preempt the reactor outcome
-        let undoCoords = DataPool.inventory().preemptiveChange(id: self.id,
-                                                               keyPath: "vAtom::vAtomType.geo_pos.coordinates",
-                                                               value: [longitude, latitude])
-
-        let undoDropped = DataPool.inventory().preemptiveChange(id: self.id,
-                                                                keyPath: "vAtom::vAtomType.dropped",
-                                                                value: true)
+        var undos: [Region.UndoFunction] = []
+        // preempt reactor outcome
+        DataPool.regions.forEach {
+            undos.append($0.preemptiveChange(id: self.id,
+                                             keyPath: "vAtom::vAtomType.geo_pos.coordinates",
+                                             value: [longitude, latitude]))
+            
+            undos.append($0.preemptiveChange(id: self.id,
+                                             keyPath: "vAtom::vAtomType.dropped",
+                                             value: true))
+        }
 
         // perform the action
-        self.performAction("Drop", payload: body, undos: [undoCoords, undoDropped], completion: completion)
+        self.performAction("Drop", payload: body, undos: undos, completion: completion)
 
     }
 
@@ -153,13 +160,14 @@ extension VatomModel {
 
         let body = ["this.id": self.id]
 
-        // preempt the reactor outcome
-        let undo = DataPool.inventory().preemptiveChange(id: self.id,
-                                                         keyPath: "vAtom::vAtomType.dropped",
-                                                         value: false)
+        var undos: [Region.UndoFunction] = []
+        // perform reactor outcome
+        DataPool.regions.forEach {
+            undos.append($0.preemptiveChange(id: self.id, keyPath: "vAtom::vAtomType.dropped", value: false))
+        }
 
         // perform the action
-        self.performAction("Pickup", payload: body, undos: [undo], completion: completion)
+        self.performAction("Pickup", payload: body, undos: undos, completion: completion)
 
     }
 

--- a/BlockV/Core/Data Pool/Helpers/Vatom+PreemptiveActions.swift
+++ b/BlockV/Core/Data Pool/Helpers/Vatom+PreemptiveActions.swift
@@ -18,7 +18,7 @@ import Foundation
 ///
 /// Actions are *preemptive* where possible. That is, data pool is updated locally before the network request is
 /// made performing the action on the server. Preemptive updates are always applied to the Inventory Region. Pickup and Drop preemtive updates
-/// are also applied to the GeoPos region.
+/// are applied to all regions.
 extension VatomModel {
 
     // MARK: - Common Actions

--- a/BlockV/Core/Data Pool/Regions/BLOCKvRegion.swift
+++ b/BlockV/Core/Data Pool/Regions/BLOCKvRegion.swift
@@ -292,8 +292,11 @@ class BLOCKvRegion: Region {
     // called in response to a premtive action
     override func onPreemptiveChange(_ object: DataObject) {
         super.onPreemptiveChange(object)
-        // indicate a re-sync with remote is required
-        object.data![keyPath: KeyPath("vAtom::vAtomType.sync")] = -1
+        
+        if object.type == "vatom" {
+            // indicate a re-sync with remote is required
+            object.data![keyPath: KeyPath("vAtom::vAtomType.sync")] = -1
+        }
     }
 
     // MARK: - Notifications

--- a/BlockV/Core/Data Pool/Regions/BLOCKvRegion.swift
+++ b/BlockV/Core/Data Pool/Regions/BLOCKvRegion.swift
@@ -288,6 +288,13 @@ class BLOCKvRegion: Region {
         return items
 
     }
+    
+    // called in response to a premtive action
+    override func onPreemptiveChange(_ object: DataObject) {
+        super.onPreemptiveChange(object)
+        // indicate a re-sync with remote is required
+        object.data![keyPath: KeyPath("vAtom::vAtomType.sync")] = -1
+    }
 
     // MARK: - Notifications
 

--- a/BlockV/Core/Data Pool/Regions/InventoryRegion.swift
+++ b/BlockV/Core/Data Pool/Regions/InventoryRegion.swift
@@ -45,6 +45,13 @@ class InventoryRegion: BLOCKvRegion {
     }
 
     var lastHash: String?
+    
+    // called in response to a premtive action
+    override func onPreemptiveChange(_ object: DataObject) {
+        super.onPreemptiveChange(object)
+        // nil out hash
+        self.lastHash = nil
+    }
 
     /// Current user ID.
     let currentUserID = DataPool.sessionInfo["userID"] as? String ?? ""

--- a/BlockV/Core/Data Pool/Regions/Region.swift
+++ b/BlockV/Core/Data Pool/Regions/Region.swift
@@ -588,6 +588,8 @@ public class Region {
         object.cached = nil
         self.emit(.willUpdateObject, userInfo: ["id": id])
         
+        self.onPreemptiveChange(object)
+        
         self.did(update: object, keyPath: keyPath, oldValue: oldValue, newValue: value)
         self.emit(.updated)
         self.save()
@@ -647,6 +649,8 @@ public class Region {
     }
 
     // MARK: - Listener functions, can be overridden by subclasses
+    
+    func onPreemptiveChange(_ object: DataObject) {}
 
     func will(add: DataObject) {}
     func will(update: DataObject, withFields: [String: Any]) {}


### PR DESCRIPTION
1. Distribute pick and drop preemptive updates to all regions.
2. Ensure preemptive changes to 'vatom' data objects (in `BLOCKvRegion` subclasses) have their `sync_nr` set as `-1`. This indicates to the region the vatom object is out of sync with remote.
3. Ensure any preemptive change in the `InventoryRegion` resets the hash to `nil`.