### PR TITLE
Core: Feature - Region additions

### DIFF
--- a/BlockV/Core/Data Pool/DataPool.swift
+++ b/BlockV/Core/Data Pool/DataPool.swift
@@ -29,6 +29,10 @@ import MapKit
 /// Region instances are created on-demand.
 /// Regions are loaded from disk cache.
 public final class DataPool {
+    
+    enum SessionError: Error {
+        case currentUserPermission
+    }
 
     /// List of available plugins, i.e. region classes.
     internal static let plugins: [Region.Type] = [
@@ -49,6 +53,10 @@ public final class DataPool {
                 reg.onSessionInfoChanged(info: sessionInfo)
             }
         }
+    }
+    
+    public static var currentUserId: String {
+        return sessionInfo["userID"] as? String ?? ""
     }
 
     /// Fetches or creates a named data region.

--- a/BlockV/Core/Data Pool/Helpers/Vatom+ChildLookup.swift
+++ b/BlockV/Core/Data Pool/Helpers/Vatom+ChildLookup.swift
@@ -56,13 +56,16 @@ extension VatomModel {
 
     /// Fetches the first-level child vatoms for this container vatom.
     ///
-    /// Only available on *owned* container vatoms. Use this function to get a best-effort snapshot of the number of
+    /// Only available on *owned* container vatoms (throws otherwise). Use this function to get a best-effort snapshot of the number of
     /// children contained by this vatom. This call is useful where getting the number of children is critical, e.g.
     /// face code in a re-use list.
     ///
     /// - important:
-    /// This method will inspect the 'inventory' region irrespective of sync state. This means the method is fast.
-    public func listCachedChildren() -> [VatomModel] {
+    /// This method will inspect the 'inventory' region irrespective of sync state. This means the method is fast but potentially unsynchronized.
+    public func listCachedChildren() throws -> [VatomModel] {
+        
+        // ensure data-pool's session owner is the vatom's owner
+        if self.props.owner != DataPool.currentUserId { throw DataPool.SessionError.currentUserPermission }
 
         // fetch children from inventory region
         let children = DataPool.inventory().getAll()

--- a/BlockV/Core/Data Pool/Regions/Region.swift
+++ b/BlockV/Core/Data Pool/Regions/Region.swift
@@ -406,6 +406,41 @@ public class Region {
         }
 
     }
+    
+    /// Returns any objects within this region with the given ids.
+    public func get(ids: [String]) -> [Any?] {
+        
+        var mappedArray: [Any?] = []
+        
+        for id in ids {
+            // get object
+            guard let object = objects[id] else {
+                mappedArray.append(nil)
+                continue
+            }
+            
+            // check for cached concrete type
+            if let cached = object.cached {
+                mappedArray.append(cached)
+            } else {
+                // map to the plugin's intended type
+                if let mapped = self.map(object) {
+                    // cache it
+                    object.cached = mapped
+                    // store it
+                    mappedArray.append(mapped)
+                } else {
+                    mappedArray.append(nil)
+                    continue
+                }
+                
+            }
+            
+        }
+        
+        return mappedArray
+        
+    }
 
     /// Returns an object within this region by it's ID.
     public func get(id: String) -> Any? {

--- a/BlockV/Core/Models/Package/Vatom/VatomModel+Containment.swift
+++ b/BlockV/Core/Models/Package/Vatom/VatomModel+Containment.swift
@@ -39,6 +39,8 @@ extension VatomModel {
 
     /// Returns `true` if this container vatom's child policy permits containment of the child vatom. `false` otherwise.
     ///
+    /// Poilcy max an min rules are evaluated locally.
+    ///
     /// Only applicable to *owned* vatoms.
     private func doesChildPolicyAllowContainmentOf(_ childVatom: VatomModel) -> Bool {
 
@@ -47,11 +49,15 @@ extension VatomModel {
 
             // check if there is a maximum number of children
             if policy.creationPolicy.enforcePolicyCountMax {
+                // get cached children (owned vatoms only)
+                guard let children = try? self.listCachedChildren() else {
+                    return false
+                }
                 // check if current child count is less then policy max
-                let children = self.listCachedChildren().filter {
+                let filteredChildren = children.filter {
                     $0.props.templateVariationID ==  policy.templateVariationID
                 }
-                if policy.creationPolicy.policyCountMax > children.count {
+                if policy.creationPolicy.policyCountMax > filteredChildren.count {
                     return true
                 }
             } else {


### PR DESCRIPTION
- Add `get(ids)` to `Region`.
- Update `listCachedChildren` to be a throwing function. This improves the safety of the function by informing the caller when the vatom is unowned, i.e. unsupported by the function.